### PR TITLE
CurveSNARK1 for Go

### DIFF
--- a/bls/mcl.go
+++ b/bls/mcl.go
@@ -9,7 +9,8 @@ import "C"
 import "fmt"
 import "unsafe"
 
-// CurveSNARK1 --
+// CurveSNARK1 -- original libsnark curve, corresponds to the curve
+// primitives on the Ethereum VM
 const CurveSNARK1 = C.mclBn_CurveSNARK1
 
 // CurveFp254BNb -- 254 bit curve

--- a/bls/mcl.go
+++ b/bls/mcl.go
@@ -9,6 +9,9 @@ import "C"
 import "fmt"
 import "unsafe"
 
+// CurveSNARK1 --
+const CurveSNARK1 = C.mclBn_CurveSNARK1
+
 // CurveFp254BNb -- 254 bit curve
 const CurveFp254BNb = C.mclBn_CurveFp254BNb
 

--- a/bls/mcl_test.go
+++ b/bls/mcl_test.go
@@ -123,6 +123,8 @@ func TestMclMain(t *testing.T) {
 	t.Logf("GetMaxOpUnitSize() = %d\n", GetMaxOpUnitSize())
 	t.Log("CurveFp254BNb")
 	testMcl(t, CurveFp254BNb)
+	t.Log("CurveSNARK1")
+	testMcl(t, CurveSNARK1)
 	if GetMaxOpUnitSize() == 6 {
 		t.Log("CurveFp382_1")
 		testMcl(t, CurveFp382_1)


### PR DESCRIPTION
Refs keep-network/keep-core#31

This PR is the second step towards exposing CurveSNARK1 to our Go code.

The plan is as follows:
1. Expose CurveSNARK1 from our fork of `bn` - done in https://github.com/keep-network/bn/pull/1
2. Expose CurveSNARK1 from our fork of `go-dfinity-crypto` <- we are here!

I added `CurveSNARK1` case to MCL test. You can run all tests with:
```
go test ./... -v
```